### PR TITLE
models: Update regions

### DIFF
--- a/models/stats.go
+++ b/models/stats.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Regions (collections)
-var Regions = []string{"MDW", "FRA", "SIN"}
+var Regions = []string{"MDW", "FRA", "SIN", "NYC", "LAX", "LON", "PRG"}
 
 // AggregatedStats are the aggregated stats for an orchestrator
 type AggregatedStats struct {


### PR DESCRIPTION
This PR updates the Regions var in the `models` package to reflect additional regions that the leaderboard API should create tables for so it can receive stats for orchestrators based on tests run in those regions.