### PR TITLE
add "until" paramater to enable time-range lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ Both MongoDB and Postgres are supported, your favorite storage layer is enabled 
 
 ## API
 
-#### `GET /api/aggregated_stats?orchestrator=<orchAddr>&region=<region_code>&since=<timestamp>`
+#### `GET /api/aggregated_stats?orchestrator=<orchAddr>&region=<region_code>&since=<timestamp>&until=<timestamp>`
 
 - The orchestrator to get aggregated stats for. If `orchestrator` is not provided the response will include aggregated scores for all orchestrators
 
 - The region to get aggregated stats for. If `region` is not provided all regions will be returned in the response. Region must be one of `"FRA", "MDW", "SIN"`.
 
-- The timestamp to evaluate the query from. If `since` is not provided it will return the results fore the last 24 hours. 
+- The timestamp to evaluate the query from. If neither `since` nor `until` are provided it will return the results fore the last 24 hours. If `until` is provided but `since` is not, it will return all results before the `until` timestamp.
+
 
 **example response** 
 

--- a/db/db.go
+++ b/db/db.go
@@ -13,8 +13,8 @@ var Store DB
 
 type DB interface {
 	InsertStats(stats *models.Stats) error
-	AggregatedStats(orch, region string, since int64) ([]*models.Stats, error)
-	RawStats(orch, region string, since int64) ([]*models.Stats, error)
+	AggregatedStats(orch, region string, since, until int64) ([]*models.Stats, error)
+	RawStats(orch, region string, since, until int64) ([]*models.Stats, error)
 }
 
 func Start() (DB, error) {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -47,7 +47,7 @@ func (db *DB) InsertStats(stats *models.Stats) error {
 	return nil
 }
 
-func (db *DB) AggregatedStats(orch, region string, since int64) ([]*models.Stats, error) {
+func (db *DB) AggregatedStats(orch, region string, since, until int64) ([]*models.Stats, error) {
 	// Query MongoDB
 	opts := options.Aggregate()
 	opts.SetAllowDiskUse(true)
@@ -57,6 +57,7 @@ func (db *DB) AggregatedStats(orch, region string, since int64) ([]*models.Stats
 	and := []bson.M{
 		{"timestamp": bson.M{
 			"$gte": since,
+			"$lte": until,
 		},
 		},
 	}
@@ -111,14 +112,17 @@ func (db *DB) AggregatedStats(orch, region string, since int64) ([]*models.Stats
 
 }
 
-func (db *DB) RawStats(orch, region string, since int64) ([]*models.Stats, error) {
+func (db *DB) RawStats(orch, region string, since, until int64) ([]*models.Stats, error) {
 	opts := options.Find()
 	// Descending: latest first
 	opts.SetSort(bson.D{{Key: "timestamp", Value: -1}})
 	filter := bson.D{
 		{
-			Key:   "timestamp",
-			Value: bson.D{{Key: "$gte", Value: since}},
+			Key: "timestamp",
+			Value: bson.D{
+				{Key: "$gte", Value: since},
+				{Key: "$lte", Value: until},
+			},
 		},
 		{
 			Key:   "orchestrator",

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -43,13 +43,13 @@ func (db *DB) InsertStats(stats *models.Stats) error {
 	return err
 }
 
-func (db *DB) AggregatedStats(orch, region string, since int64) ([]*models.Stats, error) {
+func (db *DB) AggregatedStats(orch, region string, since, until int64) ([]*models.Stats, error) {
 	qry := fmt.Sprintf(`SELECT stats->>'orchestrator', 
 	avg(CAST(stats->>'success_rate' as FLOAT)) as success_rate, 
 	avg(CAST(stats->>'seg_duration' as FLOAT)) as seg_duration, 
 	avg(CAST(stats->>'round_trip_time' as FLOAT)) as round_trip_time  
-	FROM %v WHERE (stats->>'timestamp')::int >= %v `,
-		region, since)
+	FROM %v WHERE (stats->>'timestamp')::int >= %v AND (stats->>'timestamp')::int <= %v`,
+		region, since, until)
 	if orch != "" {
 		qry += fmt.Sprintf(`AND stats->>'orchestrator' = '%v' `, orch)
 	}
@@ -82,8 +82,8 @@ func (db *DB) AggregatedStats(orch, region string, since int64) ([]*models.Stats
 	return stats, nil
 }
 
-func (db *DB) RawStats(orch, region string, since int64) ([]*models.Stats, error) {
-	qry := fmt.Sprintf(`SELECT stats FROM %v WHERE stats->>'orchestrator' = '%v' AND stats->>'timestamp' >= '%v' ORDER BY stats->>'timestamp' DESC`, region, orch, since)
+func (db *DB) RawStats(orch, region string, since, until int64) ([]*models.Stats, error) {
+	qry := fmt.Sprintf(`SELECT stats FROM %v WHERE stats->>'orchestrator' = '%v' AND stats->>'timestamp' >= '%v' AND stats->>'timestamp' <= '%v' ORDER BY stats->>'timestamp' DESC`, region, orch, since, until)
 	rows, err := db.Query(qry)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add an "until" parameter to `aggregated_stats` and `raw_stats` endpoints so that users can do time-range lookups.

## Todo

- [ ] Test