### PR TITLE
models: Add SAO region

### DIFF
--- a/models/stats.go
+++ b/models/stats.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Regions (collections)
-var Regions = []string{"MDW", "FRA", "SIN", "NYC", "LAX", "LON", "PRG"}
+var Regions = []string{"MDW", "FRA", "SIN", "NYC", "LAX", "LON", "PRG", "SAO"}
 
 // AggregatedStats are the aggregated stats for an orchestrator
 type AggregatedStats struct {


### PR DESCRIPTION
This PR updates the `Regions` var in the `models` package to include the SAO region so the leaderboard API can create a table for so it can receive stats for orchestrators based on tests run in the SAO region.

See https://github.com/livepeer/leaderboard-serverless/pull/15 for previous changes required to add additional regions.